### PR TITLE
added new javascript include tag as one in the skeleton was not working

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+    <%= javascript_include_tag "/assets/application.js", "data-turbo-track": "reload", defer: true %>
   </head>
 
   <body>


### PR DESCRIPTION
Here are more specific details: had to swap this out for the included javascript include tag as it was not registering on the host. <%= javascript_include_tag "/assets/application.js", "data-turbo-track": "reload", defer: true %>