### PR TITLE
ran a migration so that the schema would update with correct spelling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.14.2-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
     pg (1.4.6)
@@ -232,6 +234,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/app/views/workspaces/index.html.erb
+++ b/app/views/workspaces/index.html.erb
@@ -1,2 +1,1 @@
-<h1>Workspaces#index</h1>
-<p>Find me in app/views/workspaces/index.html.erb</p>
+<h1>Find a perfect place to work from home...ish</h1>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,7 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_27_123942) do
     t.float "price"
     t.string "address"
     t.string "photo"
-    t.text "desctiption"
+    t.text "description"
     t.boolean "booking_status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
I have ran a db:migrate so that the schema reflected the correct spelling for the description column in the table .